### PR TITLE
Fix #94 Provide a better description of the data model in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,28 +48,30 @@ Afterwards run it with:
 
 ## Database
 
-The database is stored in a JSON file in the `map` section. The first subsection `data` consists of the actual datapoints, representing points on a map.
+The database is stored in JSON, in the `map` section. For an example database see `tests/e2e_tests/e2e_test_data.json`. The first subsection `data` consists of the actual datapoints, representing points on a map.
 
-Datapoints have fields. The schema of these fields is defined in the subsections:
-- `filters` - fields by which datapoints can be filtered in the app. Every filter has a specified domain. Filters are obligatory fields for every datapoint and the value of a filter can be any subset of the filter's domain. For example if a database defines the filter `accessible_by` with the domain `["bikes", "cars", "pedestrians"]` then:
-```
-"accessible_by": ["bikes", "pedestrians"]
-```
-is a valid value of the field `accessible_by` for a datapoint.
-- `obligatory` - the fields that are obligatory for every datapoint but are not filters. E.g.
+Datapoints have fields. The next subsections define special types of fields:
+- `obligatory_fields` - here are explicitely stated all the fields that the application assumes are presnt in all datapoints. E.g.
 ```
 "position",
-"name"
+"name",
+"accessible_by"
+```
+- `categories` - fields that can somehow be used in the app, for example by which datapoints can be filtered. Every category has a specified list of allowed values. E.g.
+```
+"accessible_by": ["bikes", "cars", "pedestrians"]
 ```
 - `visible_data` - when a datapoint will be rendered as a pin on a map, these fields will be shown in the box when clicking on a pin. E.g.
 ```
 "name",
 "type_of_place"
 ```
-- `meta-data` - ??
+- `meta-data` - some special data like 
+```
+"UUID"
+```
 
-You can define the fields in all these subsections, keeping in mind the assumptions about them specified above. The app relies on these assumptions.
-Besides these types of fields, there is no restriction on the number of fields a datapoint can have.
+You can define the fields in all these subsections. Besides these types of fields, there is no restriction on the number of fields a datapoint can have.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -50,26 +50,25 @@ Afterwards run it with:
 
 The database is stored in a JSON file in the `map` section. The first subsection `data` consists of the actual datapoints, representing points on a map.
 
-Datapoints have fields. The schema of these fields in defined in the rest of the subsections:
-- `obligatory-filterable` - fields that are required for every datapoint and by which datapoints can be filtered in the app. These fields will have specified domains and every datapoint must have these fields set to one of the values from the domain. E.g.
+Datapoints have fields. The schema of these fields is defined in the subsections:
+- `filters` - fields by which datapoints can be filtered in the app. Every filter has a specified domain. Filters are obligatory fields for every datapoint and the value of a filter can be any subset of the filter's domain. For example if a database defines the filter `accessible_by` with the domain `["bikes", "cars", "pedestrians"]` then:
 ```
-  "type_of_place": [
-    "big bridge",
-    "small bridge"
-]
+"accessible_by": ["bikes", "pedestrians"]
 ```
-- `obligatory` - the rest of the fields that are required for every datapoint. E.g.
+is a valid value of the field `accessible_by` for a datapoint.
+- `obligatory` - the fields that are obligatory for every datapoint but are not filters. E.g.
 ```
 "position",
 "name"
 ```
-- `visible_data` - when a datapoint will be rendered as a pin on a map, these are the fields that will be shown in the box when clicking on a pin. E.g.
+- `visible_data` - when a datapoint will be rendered as a pin on a map, these fields will be shown in the box when clicking on a pin. E.g.
 ```
+"name",
 "type_of_place"
 ```
 - `meta-data` - ??
 
-You can define the fields in all these sections, keeping in mind the assumptions about them specified above. The app relies on these assumptions.
+You can define the fields in all these subsections, keeping in mind the assumptions about them specified above. The app relies on these assumptions.
 Besides these types of fields, there is no restriction on the number of fields a datapoint can have.
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -48,32 +48,29 @@ Afterwards run it with:
 
 ## Database
 
-Database consists of three sections:
+The database is stored in a JSON file in the `map` section. The first subsection `data` consists of the actual datapoints, representing points on a map.
 
-- `categories` - which informs on what categories data of points is divided
-- `visible_data` - list of categories which will be visible by application users
-- `data` - actual data split into `categories`
+Datapoints have fields. The schema of these fields in defined in the rest of the subsections:
+- `obligatory-filterable` - fields that are required for every datapoint and by which datapoints can be filtered in the app. These fields will have specified domains and every datapoint must have these fields set to one of the values from the domain. E.g.
+```
+  "type_of_place": [
+    "big bridge",
+    "small bridge"
+]
+```
+- `obligatory` - the rest of the fields that are required for every datapoint. E.g.
+```
+"position",
+"name"
+```
+- `visible_data` - when a datapoint will be rendered as a pin on a map, these are the fields that will be shown in the box when clicking on a pin. E.g.
+```
+"type_of_place"
+```
+- `meta-data` - ??
 
-
-### `categories`
-Fully configurable map where key is name of category and value is list of allowed types. E.g.
-* "car_elements": ["mirror", "wheel", "steering wheel"]
-* "color": ["red", "blue", "green"]
-
-### `data`
-Data consists of two parts:
-* obligatory and constant
-  * `name` - name of the object
-  * `position` - coordinates of object
-* category dependent - depending on your `categories` setup it varies. See example of config below.
-
-#### `custom data`
-You can define your own, more complex data types as dictionary.
-* obligatory fields in dictionary:
-  * `type` - type of data
-  * `value` - value of data
-* optional fields in dictionary:
-  * `displayValue` - value to display instead of `value`
+You can define the fields in all these sections, keeping in mind the assumptions about them specified above. The app relies on these assumptions.
+Besides these types of fields, there is no restriction on the number of fields a datapoint can have.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Datapoints have fields. The next subsections define special types of fields:
 "name",
 "accessible_by"
 ```
+TODO: `obligatory_fields` is a new subsection, start using it in the actual application
 - `categories` - fields that can somehow be used in the app, for example by which datapoints can be filtered. Every category has a specified list of allowed values. E.g.
 ```
 "accessible_by": ["bikes", "cars", "pedestrians"]

--- a/tests/e2e_tests/e2e_test_data.json
+++ b/tests/e2e_tests/e2e_test_data.json
@@ -28,6 +28,13 @@
                 "UUID": "dattarro"
             }
         ],
+        "obligatory_fields": [
+            "position",
+            "name",
+            "accessible_by",
+            "type_of_place",
+            "UUID"
+        ],
         "categories": {
             "accessible_by": [
                 "bikes",


### PR DESCRIPTION
Readme was little informative about data model. I attempt to make it more precise.

Readme stated that "name" and "position" are obligatory fields. However I have the impression that the application may rely on the fact that also other fields are present in all datapoints. For example "type_of_place" here:
https://github.com/Problematy/goodmap/blob/62c62a1c0ec952a5107bede349cd75ba8fd53882/goodmap/formatter.py#L16). \
I suggest introducing a new subsection `obligatory_fields` where you can explicitly define all such fields. This will allow the validation script to verify their presence in every datapoint.

In readme there was a paragraph of "custom data" and it mentioned something like "displayVaule". I don't know if it is necessary so I deleted it.