### PR TITLE
Add /api/version endpoint

### DIFF
--- a/goodmap/core_api.py
+++ b/goodmap/core_api.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version
+
 from flask import Blueprint, jsonify, make_response, request
 from flask_babel import gettext
 from flask_restx import Api, Resource, fields
@@ -57,6 +59,13 @@ def core_pages(
             queried_data = get_queried_data(data, categories, query_params)
             formatted_data = [prepare_pin(x, visible_data, meta_data) for x in queried_data]
             return jsonify(formatted_data)
+
+    @core_api.route("/version")
+    class Version(Resource):
+        def get(self):
+            """Shows backend version"""
+            version_info = {"backend": version("goodmap")}
+            return jsonify(version_info)
 
     @core_api.route("/categories")
     class Categories(Resource):

--- a/goodmap/core_api.py
+++ b/goodmap/core_api.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.metadata
 
 from flask import Blueprint, jsonify, make_response, request
 from flask_babel import gettext

--- a/goodmap/core_api.py
+++ b/goodmap/core_api.py
@@ -1,4 +1,4 @@
-from importlib.metadata import version
+import importlib
 
 from flask import Blueprint, jsonify, make_response, request
 from flask_babel import gettext
@@ -64,7 +64,7 @@ def core_pages(
     class Version(Resource):
         def get(self):
             """Shows backend version"""
-            version_info = {"backend": version("goodmap")}
+            version_info = {"backend": importlib.metadata.version("goodmap")}
             return jsonify(version_info)
 
     @core_api.route("/categories")

--- a/tests/unit_tests/test_core_api.py
+++ b/tests/unit_tests/test_core_api.py
@@ -13,6 +13,10 @@ def fake_translation(key: str):
     return f"{key}-translated"
 
 
+def fake_version(s: str):
+    return "0.1.2"
+
+
 @pytest.fixture
 def notifier_function():
     return MagicMock()
@@ -103,7 +107,7 @@ def test_data_endpoint_returns_data(test_app):
     ]
 
 
-@mock.patch("importlib.metadata.version", new=lambda x: "0.1.2")
+@mock.patch("importlib.metadata.version", new=fake_version)
 def test_version_endpoint_returns_version(test_app):
     response = test_app.get("/api/version")
     assert response.status_code == 200

--- a/tests/unit_tests/test_core_api.py
+++ b/tests/unit_tests/test_core_api.py
@@ -103,11 +103,11 @@ def test_data_endpoint_returns_data(test_app):
     ]
 
 
-@mock.patch("importlib.metadata.version", new=lambda: "0.3.0")
+@mock.patch("importlib.metadata.version", new=lambda x: "0.1.2")
 def test_version_endpoint_returns_version(test_app):
     response = test_app.get("/api/version")
     assert response.status_code == 200
-    assert response.json == {"backend": "0.3.0"}
+    assert response.json == {"backend": "0.1.2"}
 
 
 @mock.patch("goodmap.core_api.gettext", fake_translation)

--- a/tests/unit_tests/test_core_api.py
+++ b/tests/unit_tests/test_core_api.py
@@ -13,10 +13,6 @@ def fake_translation(key: str):
     return f"{key}-translated"
 
 
-def fake_version(s: str):
-    return "0.1.2"
-
-
 @pytest.fixture
 def notifier_function():
     return MagicMock()
@@ -107,9 +103,10 @@ def test_data_endpoint_returns_data(test_app):
     ]
 
 
-@mock.patch("importlib.metadata.version", new=fake_version)
-def test_version_endpoint_returns_version(test_app):
+@mock.patch("importlib.metadata.version", return_value="0.1.2")
+def test_version_endpoint_returns_version(mock_returning_version, test_app):
     response = test_app.get("/api/version")
+    mock_returning_version.assert_called_once_with("goodmap")
     assert response.status_code == 200
     assert response.json == {"backend": "0.1.2"}
 

--- a/tests/unit_tests/test_core_api.py
+++ b/tests/unit_tests/test_core_api.py
@@ -103,6 +103,13 @@ def test_data_endpoint_returns_data(test_app):
     ]
 
 
+@mock.patch("importlib.metadata.version", new=lambda: "0.3.0")
+def test_version_endpoint_returns_version(test_app):
+    response = test_app.get("/api/version")
+    assert response.status_code == 200
+    assert response.json == {"backend": "0.3.0"}
+
+
 @mock.patch("goodmap.core_api.gettext", fake_translation)
 @mock.patch("goodmap.formatter.gettext", fake_translation)
 @mock.patch("flask_babel.gettext", fake_translation)


### PR DESCRIPTION
Backend version is easy to obtain by `importlib.metadata`.
How about frontend version?