### PR TITLE
Add mobile e2e test

### DIFF
--- a/tests/e2e_tests/cypress/e2e/basic-test/commons.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/commons.js
@@ -1,24 +1,24 @@
-  const expectedPlace1 = {
-    title: "Grunwaldzki",
-    subtitle: "big bridge",
-    categories: [
-      ["type_of_place", "big bridge"],
-      ["accessible_by", "pedestrians, cars"]
-    ],
-    CTA: {
-      "type": "CTA",
-      "value": "https://www.example.com",
-      "displayValue": "Visit example.org!"
-    }
-  };
-  const expectedPlace2 = {
-    title: "Zwierzyniecka",
-    subtitle: "small bridge",
-    categories: [
-      ["type_of_place", "small bridge"],
-      ["accessible_by", "bikes, pedestrians"]
-    ]
-  };
+const expectedPlace1 = {
+  title: "Grunwaldzki",
+  subtitle: "big bridge",
+  categories: [
+    ["type_of_place", "big bridge"],
+    ["accessible_by", "pedestrians, cars"]
+  ],
+  CTA: {
+    "type": "CTA",
+    "value": "https://www.example.com",
+    "displayValue": "Visit example.org!"
+  }
+};
+const expectedPlace2 = {
+  title: "Zwierzyniecka",
+  subtitle: "small bridge",
+  categories: [
+    ["type_of_place", "small bridge"],
+    ["accessible_by", "bikes, pedestrians"]
+  ]
+};
 
 export const expectedPlaces = [expectedPlace1, expectedPlace2];
 
@@ -33,34 +33,34 @@ export function zoomInMap() {
 
 // TODO - Find a way to search for a specific point, not iterate over all of them
 export function verifyArbitraryPopupContent(expectedPlaces) {
-      cy.get('.point-title').should('exist').invoke('text')
-        .then((title) => {
-          const expectedPlace1 = expectedPlaces[0];
-          const expectedPlace2 = expectedPlaces[1];
-          if (title === expectedPlace1.title) {
-            verifyPopupContent(expectedPlace1);
-          } else if (title === expectedPlace2.title) {
-            verifyPopupContent(expectedPlace2);
-          }
-        });
+  cy.get('.point-title').should('exist').invoke('text')
+    .then((title) => {
+      const expectedPlace1 = expectedPlaces[0];
+      const expectedPlace2 = expectedPlaces[1];
+      if (title === expectedPlace1.title) {
+        verifyPopupContent(expectedPlace1);
+      } else if (title === expectedPlace2.title) {
+        verifyPopupContent(expectedPlace2);
+      }
+    });
 }
 
 function verifyPopupContent(expectedContent) {
-    cy.get('.point-subtitle')
-      .should('have.text', expectedContent.subtitle);
+  cy.get('.point-subtitle')
+    .should('have.text', expectedContent.subtitle);
 
-    expectedContent.categories.forEach(([category, value]) => {
-      cy.contains(category).should('exist');
-      cy.contains(value).should('exist');
-    });
+  expectedContent.categories.forEach(([category, value]) => {
+    cy.contains(category).should('exist');
+    cy.contains(value).should('exist');
+  });
 
-    if (expectedContent.CTA) {
-      cy.contains(expectedContent.CTA.displayValue).should('exist');
-      cy.contains('button', expectedContent.CTA.displayValue).click();
-      cy.get('@openStub').should('have.been.calledOnceWith',
-        expectedContent.CTA.value, '_blank');
-    }
+  if (expectedContent.CTA) {
+    cy.contains(expectedContent.CTA.displayValue).should('exist');
+    cy.contains('button', expectedContent.CTA.displayValue).click();
+    cy.get('@openStub').should('have.been.calledOnceWith',
+      expectedContent.CTA.value, '_blank');
   }
+}
 
 export function verifyProblemForm() {
   cy.contains('report a problem').should('exist').click();

--- a/tests/e2e_tests/cypress/e2e/basic-test/commons.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/commons.js
@@ -1,3 +1,27 @@
+  const expectedPlace1 = {
+    title: "Grunwaldzki",
+    subtitle: "big bridge",
+    categories: [
+      ["type_of_place", "big bridge"],
+      ["accessible_by", "pedestrians, cars"]
+    ],
+    CTA: {
+      "type": "CTA",
+      "value": "https://www.example.com",
+      "displayValue": "Visit example.org!"
+    }
+  };
+  const expectedPlace2 = {
+    title: "Zwierzyniecka",
+    subtitle: "small bridge",
+    categories: [
+      ["type_of_place", "small bridge"],
+      ["accessible_by", "bikes, pedestrians"]
+    ]
+  };
+
+export const expectedPlaces = [expectedPlace1, expectedPlace2];
+
 const zoomInTimes = 1;
 
 export function zoomInMap() {
@@ -6,23 +30,6 @@ export function zoomInMap() {
     cy.wait(500);
   }
 }
-
-export function verifyPopupContent(expectedContent) {
-    cy.get('.point-subtitle')
-      .should('have.text', expectedContent.subtitle);
-
-    expectedContent.categories.forEach(([category, value]) => {
-      cy.contains(category).should('exist');
-      cy.contains(value).should('exist');
-    });
-
-    if (expectedContent.CTA) {
-      cy.contains(expectedContent.CTA.displayValue).should('exist');
-      cy.contains('button', expectedContent.CTA.displayValue).click();
-      cy.get('@openStub').should('have.been.calledOnceWith',
-        expectedContent.CTA.value, '_blank');
-    }
-  }
 
 // TODO - Find a way to search for a specific point, not iterate over all of them
 export function verifyArbitraryPopupContent(expectedPlaces) {
@@ -38,34 +45,22 @@ export function verifyArbitraryPopupContent(expectedPlaces) {
         });
 }
 
+function verifyPopupContent(expectedContent) {
+    cy.get('.point-subtitle')
+      .should('have.text', expectedContent.subtitle);
 
-function desktopTest() {
-    zoomInMap();
-
-    cy.get('.leaflet-marker-icon').each(($marker) => {
-      cy.wrap($marker).click();
-      cy.wait(500);
-      verifyPopupElementsOnDesktop();
+    expectedContent.categories.forEach(([category, value]) => {
+      cy.contains(category).should('exist');
+      cy.contains(value).should('exist');
     });
-}
 
-function MobileTest() {
-      cy.on('window:before:load', (win) => {
-        Object.defineProperty(win.navigator, 'userAgent', {
-          value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
-        });
-      })
-
-    zoomInMap();
-
-    cy.get('.leaflet-marker-icon').each(($marker) => {
-      cy.wrap($marker).click();
-      cy.wait(500);
-      verifyPopupElementsOnMobile
-    });
-}
-
-
+    if (expectedContent.CTA) {
+      cy.contains(expectedContent.CTA.displayValue).should('exist');
+      cy.contains('button', expectedContent.CTA.displayValue).click();
+      cy.get('@openStub').should('have.been.calledOnceWith',
+        expectedContent.CTA.value, '_blank');
+    }
+  }
 
 export function verifyProblemForm() {
   cy.contains('report a problem').should('exist').click();
@@ -90,32 +85,4 @@ export function verifyProblemForm() {
     cy.get('input[name="problem"]').type('Custom issue description');
     cy.get('input[type="submit"]').should('exist').click();
   });
-
-}
-
-function verifyPopupElementsOnDesktop() {
-      cy.get('.leaflet-popup-content').should('exist')
-        .within(() => {
-          verifyArbitraryPopupContent(expectedPlaces);
-
-          verifyProblemForm();
-        });
-      cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
-        cy.wrap($button).click();
-        cy.wait(500);
-      });
-}
-
-function verifyPopupElementsOnMobile() {
-      cy.get('.MuiDialogContent-root').should('exist')
-        .within(() => {
-          verifyArbitraryPopupContent(expectedPlaces);
-
-          verifyProblemForm();
-          // Verify "navigate me" button
-        });
-        cy.get('.MuiIconButton-root').should('exist').then(($button) => {
-          cy.wrap($button).click();
-          cy.wait(500);
-        });
 }

--- a/tests/e2e_tests/cypress/e2e/basic-test/commons.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/commons.js
@@ -22,15 +22,6 @@ const expectedPlace2 = {
 
 export const expectedPlaces = [expectedPlace1, expectedPlace2];
 
-const zoomInTimes = 1;
-
-export function zoomInMap() {
-  for (let i = 0; i < zoomInTimes; i++) {
-    cy.get('.leaflet-marker-icon').first().click();
-    cy.wait(500);
-  }
-}
-
 // TODO - Find a way to search for a specific point, not iterate over all of them
 export function verifyArbitraryPopupContent(expectedPlaces) {
   cy.get('.point-title').should('exist').invoke('text')

--- a/tests/e2e_tests/cypress/e2e/basic-test/commons.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/commons.js
@@ -1,0 +1,118 @@
+const zoomInTimes = 1;
+
+function zoomInMap() {
+  for (let i = 0; i < zoomInTimes; i++) {
+    cy.get('.leaflet-marker-icon').first().click();
+    cy.wait(500);
+  }
+}
+
+function verifyPopupContent(expectedContent) {
+    cy.get('.point-subtitle')
+      .should('have.text', expectedContent.subtitle);
+
+    expectedContent.categories.forEach(([category, value]) => {
+      cy.contains(category).should('exist');
+      cy.contains(value).should('exist');
+    });
+
+    if (expectedContent.CTA) {
+      cy.contains(expectedContent.CTA.displayValue).should('exist');
+      cy.contains('button', expectedContent.CTA.displayValue).click();
+      cy.get('@openStub').should('have.been.calledOnceWith',
+        expectedContent.CTA.value, '_blank');
+    }
+  }
+
+function verifyArbitraryPopupContent(expectedPlaces) {
+      cy.get('.point-title').should('exist').invoke('text')
+        .then((title) => {
+          if (title === expectedPlace1.title) {
+            verifyPopupContent(expectedPlace1);
+          } else if (title === expectedPlace2.title) {
+            verifyPopupContent(expectedPlace2);
+          }
+        });
+}
+
+
+function desktopTest() {
+    zoomInMap();
+
+    cy.get('.leaflet-marker-icon').each(($marker) => {
+      cy.wrap($marker).click();
+      cy.wait(500);
+      verifyPopupElementsOnDesktop();
+    });
+}
+
+function MobileTest() {
+      cy.on('window:before:load', (win) => {
+        Object.defineProperty(win.navigator, 'userAgent', {
+          value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+        });
+      })
+
+    zoomInMap();
+
+    cy.get('.leaflet-marker-icon').each(($marker) => {
+      cy.wrap($marker).click();
+      cy.wait(500);
+      verifyPopupElementsOnMobile
+    });
+}
+
+
+
+function verifyProblemForm() {
+  cy.contains('report a problem').should('exist').click();
+
+  cy.get('form').should('exist').within(() => {
+    cy.get('select').should('exist').within(() => {
+      cy.get('option').then((options) => {
+        const optionValues = [...options].map(option => option.textContent.trim());
+        expect(optionValues).to.include.members([
+          '--Please choose an option--',
+          'this point is not here',
+          "it's overloaded",
+          "it's broken",
+          'other',
+        ]);
+      });
+    });
+
+    cy.get('select').select('other');
+    cy.get('input[name="problem"]').should('exist');
+
+    cy.get('input[name="problem"]').type('Custom issue description');
+    cy.get('input[type="submit"]').should('exist').click();
+  });
+
+}
+
+function verifyPopupElementsOnDesktop() {
+      cy.get('.leaflet-popup-content').should('exist')
+        .within(() => {
+          verifyArbitraryPopupContent(expectedPlaces);
+
+          verifyProblemForm();
+        });
+      cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
+        cy.wrap($button).click();
+        cy.wait(500);
+      });
+}
+
+function verifyPopupElementsOnMobile() {
+      cy.get('.MuiDialogContent-root').should('exist')
+        .within(() => {
+          verifyArbitraryPopupContent(expectedPlaces);
+
+          verifyProblemForm();
+          // Verify "navigate me" button
+        }
+        cy.get('.MuiIconButton-root').should('exist').then(($button) => {
+          cy.wrap($button).click();
+          cy.wait(500);
+        });
+}

--- a/tests/e2e_tests/cypress/e2e/basic-test/commons.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/commons.js
@@ -55,6 +55,7 @@ function verifyPopupContent(expectedContent) {
 
 export function verifyProblemForm() {
   cy.contains('report a problem').should('exist').click();
+  cy.intercept('POST', '/api/report-location').as('reportLocation');
 
   cy.get('form').should('exist').within(() => {
     cy.get('select').should('exist').within(() => {
@@ -72,8 +73,18 @@ export function verifyProblemForm() {
 
     cy.get('select').select('other');
     cy.get('input[name="problem"]').should('exist');
-
     cy.get('input[name="problem"]').type('Custom issue description');
     cy.get('input[type="submit"]').should('exist').click();
   });
+
+  cy.wait('@reportLocation').then((interception) => {
+    expect(interception.request.body).to.have.property('id');
+    expect(interception.request.body).to.have.property('description');
+    expect(interception.request.body.description).to.equal('Custom issue description');
+    expect(interception.response.statusCode).to.equal(200);
+    expect(interception.response.body.message).to.equal('Location reported');
+  });
+
+  cy.contains('p', 'Location reported').should('exist');
+  cy.get('form').should('not.exist');
 }

--- a/tests/e2e_tests/cypress/e2e/basic-test/commons.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/commons.js
@@ -1,13 +1,13 @@
 const zoomInTimes = 1;
 
-function zoomInMap() {
+export function zoomInMap() {
   for (let i = 0; i < zoomInTimes; i++) {
     cy.get('.leaflet-marker-icon').first().click();
     cy.wait(500);
   }
 }
 
-function verifyPopupContent(expectedContent) {
+export function verifyPopupContent(expectedContent) {
     cy.get('.point-subtitle')
       .should('have.text', expectedContent.subtitle);
 
@@ -24,9 +24,12 @@ function verifyPopupContent(expectedContent) {
     }
   }
 
-function verifyArbitraryPopupContent(expectedPlaces) {
+// TODO - Find a way to search for a specific point, not iterate over all of them
+export function verifyArbitraryPopupContent(expectedPlaces) {
       cy.get('.point-title').should('exist').invoke('text')
         .then((title) => {
+          const expectedPlace1 = expectedPlaces[0];
+          const expectedPlace2 = expectedPlaces[1];
           if (title === expectedPlace1.title) {
             verifyPopupContent(expectedPlace1);
           } else if (title === expectedPlace2.title) {
@@ -64,7 +67,7 @@ function MobileTest() {
 
 
 
-function verifyProblemForm() {
+export function verifyProblemForm() {
   cy.contains('report a problem').should('exist').click();
 
   cy.get('form').should('exist').within(() => {
@@ -110,7 +113,7 @@ function verifyPopupElementsOnMobile() {
 
           verifyProblemForm();
           // Verify "navigate me" button
-        }
+        });
         cy.get('.MuiIconButton-root').should('exist').then(($button) => {
           cy.wrap($button).click();
           cy.wait(500);

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -1,6 +1,5 @@
 describe('Popup Tests on Mobile', () => {
   const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10']
-//  const viewports = ['iphone-x']
 
   const expectedPlace1 = {
     title: "Grunwaldzki",
@@ -35,9 +34,8 @@ describe('Popup Tests on Mobile', () => {
       })
       cy.viewport(viewport);
 
-//      cy.reload();
       cy.visit('/');
-    cy.wait(500);
+      cy.wait(500);
 
 
       cy.window().then((win) => {

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -1,9 +1,6 @@
 describe('Popup Tests on Mobile', () => {
-//  const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10']
-  const viewports = ['iphone-x']
-  beforeEach(() => {
-
-  });
+  const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10']
+//  const viewports = ['iphone-x']
 
   const expectedPlace1 = {
     title: "Grunwaldzki",
@@ -30,35 +27,23 @@ describe('Popup Tests on Mobile', () => {
   viewports.forEach((viewport) => {
 
     it(`displays title and subtitle in the popup on ${viewport}`, () => {
-      cy.window().then((win) => {
-        cy.stub(win, 'open').as('openStub');
-
-        const updateIsMobile = () => {
-          win.isMobile = win.innerWidth <= 7068; // Update `isMobile` dynamically
-        };
-
-        // Attach the event listener to the window object
-        win.addEventListener('resize', updateIsMobile);
-
-        // Perform an initial check
-        updateIsMobile();
-      });
-
 
       cy.on('window:before:load', (win) => {
         Object.defineProperty(win.navigator, 'userAgent', {
           value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
         });
       })
-    cy.visit('/');
-    cy.wait(1000);
       cy.viewport(viewport);
 
-      cy.wait(1000);
+//      cy.reload();
+      cy.visit('/');
+    cy.wait(500);
+
 
       cy.window().then((win) => {
-        expect(win.isMobile).to.be.true; // Should be true for 'iphone-6'
+        cy.stub(win, 'open').as('openStub');
       });
+
 
 
       const zoomInTimes = 1;
@@ -72,7 +57,7 @@ describe('Popup Tests on Mobile', () => {
         cy.wrap($marker).click({ force: true });
         cy.wait(500);
 
-        cy.get('.leaflet-popup-content').should('exist')
+        cy.get('.MuiDialogContent-root').should('exist')
           .within(() => {
 
             function verifyPopupContent(expectedContent) {
@@ -126,7 +111,7 @@ describe('Popup Tests on Mobile', () => {
 
           });
 
-        cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
+        cy.get('.MuiIconButton-root').should('exist').then(($button) => {
           cy.wrap($button).click({ force: true });
           cy.wait(500);
         });

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -1,4 +1,4 @@
-import { zoomInMap, verifyArbitraryPopupContent, verifyProblemForm, expectedPlaces } from "./commons.js"
+import { verifyArbitraryPopupContent, verifyProblemForm, expectedPlaces } from "./commons.js"
 
 describe('Popup Tests on Mobile', () => {
   const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10'];

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -1,0 +1,119 @@
+describe('Popup Tests on Mobile', () => {
+  const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10']
+  beforeEach(() => {
+    cy.visit('/');
+    cy.wait(1000);
+  });
+
+  const expectedPlace1 = {
+    title: "Grunwaldzki",
+    subtitle: "big bridge",
+    categories: [
+      ["type_of_place", "big bridge"],
+      ["accessible_by", "pedestrians, cars"]
+    ],
+    CTA: {
+      "type": "CTA",
+      "value": "https://www.example.com",
+      "displayValue": "Visit example.org!"
+    }
+  };
+  const expectedPlace2 = {
+    title: "Zwierzyniecka",
+    subtitle: "small bridge",
+    categories: [
+      ["type_of_place", "small bridge"],
+      ["accessible_by", "bikes, pedestrians"]
+    ]
+  };
+
+  viewports.forEach((viewport) => {
+
+    it(`displays title and subtitle in the popup on ${viewport}`, () => {
+      cy.viewport(viewport);
+      cy.window().then((win) => {
+        cy.stub(win, 'open').as('openStub');
+      });
+
+      const zoomInTimes = 1;
+      for (let i = 0; i < zoomInTimes; i++) {
+        cy.get('.leaflet-marker-icon').first().click({ force: true }); // Force click for mobile
+        cy.wait(500);
+      }
+
+      // TODO - Find a way to search for a specific point, not iterate over all of them
+      cy.get('.leaflet-marker-icon').each(($marker) => {
+        cy.wrap($marker).click({ force: true }); // Force click for mobile
+        cy.wait(500);
+
+        cy.get('.leaflet-popup-content').should('exist')
+          .within(() => {
+
+            function verifyPopupContent(expectedContent) {
+              cy.get('.point-subtitle')
+                .should('have.text', expectedContent.subtitle);
+
+              expectedContent.categories.forEach(([category, value]) => {
+                cy.contains(category).should('exist');
+                cy.contains(value).should('exist');
+              });
+
+              if (expectedContent.CTA) {
+                cy.contains(expectedContent.CTA.displayValue).should('exist');
+                cy.contains('button', expectedContent.CTA.displayValue).click({ force: true });
+                cy.get('@openStub').should('have.been.calledOnceWith',
+                  expectedContent.CTA.value, '_blank');
+              }
+            }
+
+
+            cy.get('.point-title').should('exist').invoke('text')
+              .then((title) => {
+                if (title === expectedPlace1.title) {
+                  verifyPopupContent(expectedPlace1);
+                } else if (title === expectedPlace2.title) {
+                  verifyPopupContent(expectedPlace2);
+                }
+              });
+          });
+
+        cy.contains('report a problem').should('exist').click();
+
+          // Verify the form appears
+          cy.get('form').should('exist').within(() => {
+            // Verify dropdown options
+            cy.get('select').should('exist').within(() => {
+              cy.get('option').then((options) => {
+                const optionValues = [...options].map(option => option.value);
+                expect(optionValues).to.include.members([
+                  '',
+                  'reportNotHere',
+                  'reportOverload',
+                  'reportBroken',
+                  'reportOther',
+                ]);
+              });
+            });
+
+            // Select a problem type and verify behavior
+            cy.get('select').select('reportOther'); // Assuming "Other" is localized correctly
+            cy.get('input[name="problem"]').should('exist'); // Text input for "Other"
+
+            // Fill out the form
+            cy.get('input[name="problem"]').type('Custom issue description');
+            cy.get('input[type="submit"]').should('exist').click();
+          });
+
+          // Verify the success message
+          cy.get('form').should('not.exist'); // Form should no longer be visible
+          cy.contains('p', /thank you/i).should('exist'); // Adjust message as per actual text
+
+        cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
+          cy.wrap($button).click({ force: true });
+          cy.wait(500);
+        });
+      });
+      });
+  });
+
+});

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -19,7 +19,8 @@ describe('Popup Tests on Mobile', () => {
         cy.stub(win, 'open').as('openStub');
       });
 
-      zoomInMap();
+      cy.get('.leaflet-marker-icon').first().click();
+      cy.wait(500);
 
       cy.get('.leaflet-marker-icon').each(($marker) => {
         cy.wrap($marker).click();

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -79,25 +79,22 @@ describe('Popup Tests on Mobile', () => {
 
   // Verify the form appears
   cy.get('form').should('exist').within(() => {
-    // Open the dropdown by clicking on it
-    cy.get('select').should('exist')
-
-    cy.get('--Please choose an option--').should('exist').click();
-
-    // Verify dropdown options are displayed
-    cy.get('select option').then((options) => {
+  // Verify dropdown options
+  cy.get('select').should('exist').within(() => {
+    cy.get('option').then((options) => {
       const optionValues = [...options].map(option => option.textContent.trim());
       expect(optionValues).to.include.members([
         '--Please choose an option--',
-        'Not here',
-        'Overloaded',
-        'Broken',
-        'Other',
+        'this point is not here',
+        "it's overloaded",
+        "it's broken",
+        'other',
       ]);
     });
+  });
 
     // Select the "Other" option and verify the text input appears
-    cy.get('select').select('Other'); // Assuming "Other" is the visible text
+    cy.get('select').select('other'); // Assuming "Other" is the visible text
     cy.get('input[name="problem"]').should('exist'); // Text input for "Other"
 
     // Fill out the form
@@ -108,9 +105,9 @@ describe('Popup Tests on Mobile', () => {
           });
 
 
-        // Verify the success message
-        cy.get('form').should('not.exist'); // Form should no longer be visible
-        cy.contains('p', /thank you/i).should('exist'); // Adjust message as per actual text
+//        // Verify the success message
+//        cy.get('form').should('not.exist'); // Form should no longer be visible
+//        cy.contains('p', /thank you/i).should('exist'); // Adjust message as per actual text
 
         cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
           cy.wrap($button).click({ force: true });

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -37,13 +37,13 @@ describe('Popup Tests on Mobile', () => {
 
       const zoomInTimes = 1;
       for (let i = 0; i < zoomInTimes; i++) {
-        cy.get('.leaflet-marker-icon').first().click({ force: true }); // Force click for mobile
+        cy.get('.leaflet-marker-icon').first().click({ force: true });
         cy.wait(500);
       }
 
       // TODO - Find a way to search for a specific point, not iterate over all of them
       cy.get('.leaflet-marker-icon').each(($marker) => {
-        cy.wrap($marker).click({ force: true }); // Force click for mobile
+        cy.wrap($marker).click({ force: true });
         cy.wait(500);
 
         cy.get('.leaflet-popup-content').should('exist')
@@ -77,9 +77,7 @@ describe('Popup Tests on Mobile', () => {
               });
         cy.contains('report a problem').should('exist').click({ force: true });
 
-  // Verify the form appears
   cy.get('form').should('exist').within(() => {
-  // Verify dropdown options
   cy.get('select').should('exist').within(() => {
     cy.get('option').then((options) => {
       const optionValues = [...options].map(option => option.textContent.trim());
@@ -93,21 +91,14 @@ describe('Popup Tests on Mobile', () => {
     });
   });
 
-    // Select the "Other" option and verify the text input appears
-    cy.get('select').select('other'); // Assuming "Other" is the visible text
-    cy.get('input[name="problem"]').should('exist'); // Text input for "Other"
+    cy.get('select').select('other');
+    cy.get('input[name="problem"]').should('exist');
 
-    // Fill out the form
     cy.get('input[name="problem"]').type('Custom issue description');
     cy.get('input[type="submit"]').should('exist').click();
   });
 
           });
-
-
-//        // Verify the success message
-//        cy.get('form').should('not.exist'); // Form should no longer be visible
-//        cy.contains('p', /thank you/i).should('exist'); // Adjust message as per actual text
 
         cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
           cy.wrap($button).click({ force: true });

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -1,36 +1,11 @@
-import {zoomInMap, verifyPopupContent, verifyArbitraryPopupContent, verifyProblemForm} from "./commons.js"
-
-  const expectedPlace1 = {
-    title: "Grunwaldzki",
-    subtitle: "big bridge",
-    categories: [
-      ["type_of_place", "big bridge"],
-      ["accessible_by", "pedestrians, cars"]
-    ],
-    CTA: {
-      "type": "CTA",
-      "value": "https://www.example.com",
-      "displayValue": "Visit example.org!"
-    }
-  };
-  const expectedPlace2 = {
-    title: "Zwierzyniecka",
-    subtitle: "small bridge",
-    categories: [
-      ["type_of_place", "small bridge"],
-      ["accessible_by", "bikes, pedestrians"]
-    ]
-  };
-
-const expectedPlaces = [expectedPlace1, expectedPlace2];
+import {zoomInMap, verifyArbitraryPopupContent, verifyProblemForm, expectedPlaces} from "./commons.js"
 
 describe('Popup Tests on Mobile', () => {
-  const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10']
+  const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10'];
 
   viewports.forEach((viewport) => {
 
     it(`displays title and subtitle in the popup on ${viewport}`, () => {
-
       cy.on('window:before:load', (win) => {
         Object.defineProperty(win.navigator, 'userAgent', {
           value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -2,8 +2,7 @@ describe('Popup Tests on Mobile', () => {
 //  const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10']
   const viewports = ['iphone-x']
   beforeEach(() => {
-    cy.visit('/');
-    cy.wait(1000);
+
   });
 
   const expectedPlace1 = {
@@ -31,10 +30,36 @@ describe('Popup Tests on Mobile', () => {
   viewports.forEach((viewport) => {
 
     it(`displays title and subtitle in the popup on ${viewport}`, () => {
-      cy.viewport(viewport);
       cy.window().then((win) => {
         cy.stub(win, 'open').as('openStub');
+
+        const updateIsMobile = () => {
+          win.isMobile = win.innerWidth <= 7068; // Update `isMobile` dynamically
+        };
+
+        // Attach the event listener to the window object
+        win.addEventListener('resize', updateIsMobile);
+
+        // Perform an initial check
+        updateIsMobile();
       });
+
+
+      cy.on('window:before:load', (win) => {
+        Object.defineProperty(win.navigator, 'userAgent', {
+          value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+        });
+      })
+    cy.visit('/');
+    cy.wait(1000);
+      cy.viewport(viewport);
+
+      cy.wait(1000);
+
+      cy.window().then((win) => {
+        expect(win.isMobile).to.be.true; // Should be true for 'iphone-6'
+      });
+
 
       const zoomInTimes = 1;
       for (let i = 0; i < zoomInTimes; i++) {
@@ -76,28 +101,28 @@ describe('Popup Tests on Mobile', () => {
                   verifyPopupContent(expectedPlace2);
                 }
               });
-        cy.contains('report a problem').should('exist').click({ force: true });
+            cy.contains('report a problem').should('exist').click({ force: true });
 
-  cy.get('form').should('exist').within(() => {
-  cy.get('select').should('exist').within(() => {
-    cy.get('option').then((options) => {
-      const optionValues = [...options].map(option => option.textContent.trim());
-      expect(optionValues).to.include.members([
-        '--Please choose an option--',
-        'this point is not here',
-        "it's overloaded",
-        "it's broken",
-        'other',
-      ]);
-    });
-  });
+            cy.get('form').should('exist').within(() => {
+              cy.get('select').should('exist').within(() => {
+                cy.get('option').then((options) => {
+                  const optionValues = [...options].map(option => option.textContent.trim());
+                  expect(optionValues).to.include.members([
+                    '--Please choose an option--',
+                    'this point is not here',
+                    "it's overloaded",
+                    "it's broken",
+                    'other',
+                  ]);
+                });
+              });
 
-    cy.get('select').select('other');
-    cy.get('input[name="problem"]').should('exist');
+              cy.get('select').select('other');
+              cy.get('input[name="problem"]').should('exist');
 
-    cy.get('input[name="problem"]').type('Custom issue description');
-    cy.get('input[type="submit"]').should('exist').click();
-  });
+              cy.get('input[name="problem"]').type('Custom issue description');
+              cy.get('input[type="submit"]').should('exist').click();
+            });
 
           });
 

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -75,45 +75,49 @@ describe('Popup Tests on Mobile', () => {
                   verifyPopupContent(expectedPlace2);
                 }
               });
+        cy.contains('report a problem').should('exist').click({ force: true });
+
+  // Verify the form appears
+  cy.get('form').should('exist').within(() => {
+    // Open the dropdown by clicking on it
+    cy.get('select').should('exist')
+
+    cy.get('--Please choose an option--').should('exist').click();
+
+    // Verify dropdown options are displayed
+    cy.get('select option').then((options) => {
+      const optionValues = [...options].map(option => option.textContent.trim());
+      expect(optionValues).to.include.members([
+        '--Please choose an option--',
+        'Not here',
+        'Overloaded',
+        'Broken',
+        'Other',
+      ]);
+    });
+
+    // Select the "Other" option and verify the text input appears
+    cy.get('select').select('Other'); // Assuming "Other" is the visible text
+    cy.get('input[name="problem"]').should('exist'); // Text input for "Other"
+
+    // Fill out the form
+    cy.get('input[name="problem"]').type('Custom issue description');
+    cy.get('input[type="submit"]').should('exist').click();
+  });
+
           });
 
-        cy.contains('report a problem').should('exist').click();
 
-          // Verify the form appears
-          cy.get('form').should('exist').within(() => {
-            // Verify dropdown options
-            cy.get('select').should('exist').within(() => {
-              cy.get('option').then((options) => {
-                const optionValues = [...options].map(option => option.value);
-                expect(optionValues).to.include.members([
-                  '',
-                  'reportNotHere',
-                  'reportOverload',
-                  'reportBroken',
-                  'reportOther',
-                ]);
-              });
-            });
-
-            // Select a problem type and verify behavior
-            cy.get('select').select('reportOther'); // Assuming "Other" is localized correctly
-            cy.get('input[name="problem"]').should('exist'); // Text input for "Other"
-
-            // Fill out the form
-            cy.get('input[name="problem"]').type('Custom issue description');
-            cy.get('input[type="submit"]').should('exist').click();
-          });
-
-          // Verify the success message
-          cy.get('form').should('not.exist'); // Form should no longer be visible
-          cy.contains('p', /thank you/i).should('exist'); // Adjust message as per actual text
+        // Verify the success message
+        cy.get('form').should('not.exist'); // Form should no longer be visible
+        cy.contains('p', /thank you/i).should('exist'); // Adjust message as per actual text
 
         cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
           cy.wrap($button).click({ force: true });
           cy.wait(500);
         });
       });
-      });
+    });
   });
 
 });

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -1,5 +1,6 @@
 describe('Popup Tests on Mobile', () => {
-  const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10']
+//  const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10']
+  const viewports = ['iphone-x']
   beforeEach(() => {
     cy.visit('/');
     cy.wait(1000);

--- a/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/mobile-box-test.cy.js
@@ -1,4 +1,4 @@
-import {zoomInMap, verifyArbitraryPopupContent, verifyProblemForm, expectedPlaces} from "./commons.js"
+import { zoomInMap, verifyArbitraryPopupContent, verifyProblemForm, expectedPlaces } from "./commons.js"
 
 describe('Popup Tests on Mobile', () => {
   const viewports = ['iphone-x', 'iphone-6', 'ipad-2', 'samsung-s10'];
@@ -21,20 +21,20 @@ describe('Popup Tests on Mobile', () => {
 
       zoomInMap();
 
-        cy.get('.leaflet-marker-icon').each(($marker) => {
-          cy.wrap($marker).click();
-          cy.wait(500);
+      cy.get('.leaflet-marker-icon').each(($marker) => {
+        cy.wrap($marker).click();
+        cy.wait(500);
 
-          cy.get('.MuiDialogContent-root').should('exist')
-            .within(() => {
-              verifyArbitraryPopupContent(expectedPlaces);
-              verifyProblemForm();
-            });
-          cy.get('.MuiIconButton-root').should('exist').then(($button) => {
-            cy.wrap($button).click();
-            cy.wait(500);
+        cy.get('.MuiDialogContent-root').should('exist')
+          .within(() => {
+            verifyArbitraryPopupContent(expectedPlaces);
+            verifyProblemForm();
           });
+        cy.get('.MuiIconButton-root').should('exist').then(($button) => {
+          cy.wrap($button).click();
+          cy.wait(500);
         });
+      });
     });
   });
 });

--- a/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
@@ -1,4 +1,4 @@
-import { zoomInMap, verifyArbitraryPopupContent, expectedPlaces } from "./commons.js"
+import { verifyArbitraryPopupContent, expectedPlaces } from "./commons.js"
 
 describe('Popup Tests', () => {
   beforeEach(() => {

--- a/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
@@ -1,4 +1,4 @@
-import {zoomInMap, verifyArbitraryPopupContent, verifyProblemForm, expectedPlaces} from "./commons.js"
+import { zoomInMap, verifyArbitraryPopupContent, expectedPlaces } from "./commons.js"
 
 describe('Popup Tests', () => {
   beforeEach(() => {
@@ -20,8 +20,8 @@ describe('Popup Tests', () => {
         .within(() => {
           verifyArbitraryPopupContent(expectedPlaces);
 
-        // TODO BUG: when problem form is opened on desktop, the close button may be hidden
-        // Fix this and add checking problem form in this test
+          // TODO BUG: when problem form is opened on desktop, the close button may be hidden
+          // Fix this and add checking problem form in this test
         });
       cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
         cy.wrap($button).click();

--- a/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
@@ -1,3 +1,6 @@
+import {zoomInMap, verifyPopupContent, verifyArbitraryPopupContent, verifyProblemForm} from "./commons.js"
+
+
 describe('Popup Tests', () => {
   beforeEach(() => {
     cy.visit('/');
@@ -24,56 +27,29 @@ describe('Popup Tests', () => {
       ["accessible_by", "bikes, pedestrians"]
     ]
   }
+const expectedPlaces = [expectedPlace1, expectedPlace2];
+
 
   it('displays title and subtitle in the popup', () => {
     cy.window().then((win) => {
       cy.stub(win, 'open').as('openStub');
     });
 
-    const zoomInTimes = 1;
-    for (let i = 0; i < zoomInTimes; i++) {
-      cy.get('.leaflet-marker-icon').first().click();
-      cy.wait(500);
-    }
+    zoomInMap();
 
-    // TODO - Find a way to search for a specific point, not iterate over all of them
     cy.get('.leaflet-marker-icon').each(($marker) => {
       cy.wrap($marker).click();
       cy.wait(500);
-
       cy.get('.leaflet-popup-content').should('exist')
         .within(() => {
-          function verifyPopupContent(expectedContent) {
-            cy.get('.point-subtitle')
-              .should('have.text', expectedContent.subtitle);
+          verifyArbitraryPopupContent(expectedPlaces);
 
-            expectedContent.categories.forEach(([category, value]) => {
-              cy.contains(category).should('exist');
-              cy.contains(value).should('exist');
-            });
-
-            if (expectedContent.CTA) {
-              cy.contains(expectedContent.CTA.displayValue).should('exist');
-              cy.contains('button', expectedContent.CTA.displayValue).click();
-              cy.get('@openStub').should('have.been.calledOnceWith',
-                expectedContent.CTA.value, '_blank');
-            }
-          }
-
-          cy.get('.point-title').should('exist').invoke('text')
-            .then((title) => {
-              if (title === expectedPlace1.title) {
-                verifyPopupContent(expectedPlace1);
-              } else if (title === expectedPlace2.title) {
-                verifyPopupContent(expectedPlace2);
-              }
-            });
+//          verifyProblemForm();
         });
-
       cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
         cy.wrap($button).click();
         cy.wait(500);
-      })
+      });
     });
   });
 });

--- a/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
@@ -11,7 +11,8 @@ describe('Popup Tests', () => {
       cy.stub(win, 'open').as('openStub');
     });
 
-    zoomInMap();
+    cy.get('.leaflet-marker-icon').first().click();
+    cy.wait(500);
 
     cy.get('.leaflet-marker-icon').each(($marker) => {
       cy.wrap($marker).click();

--- a/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
+++ b/tests/e2e_tests/cypress/e2e/basic-test/popup-test.cy.js
@@ -1,34 +1,10 @@
-import {zoomInMap, verifyPopupContent, verifyArbitraryPopupContent, verifyProblemForm} from "./commons.js"
-
+import {zoomInMap, verifyArbitraryPopupContent, verifyProblemForm, expectedPlaces} from "./commons.js"
 
 describe('Popup Tests', () => {
   beforeEach(() => {
     cy.visit('/');
-    cy.wait(1000);
+    cy.wait(500);
   })
-  const expectedPlace1 = {
-    title: "Grunwaldzki",
-    subtitle: "big bridge",
-    categories: [
-      ["type_of_place", "big bridge"],
-      ["accessible_by", "pedestrians, cars"]
-    ],
-    CTA: {
-      "type": "CTA",
-      "value": "https://www.example.com",
-      "displayValue": "Visit example.org!"
-    }
-  }
-  const expectedPlace2 = {
-    title: "Zwierzyniecka",
-    subtitle: "small bridge",
-    categories: [
-      ["type_of_place", "small bridge"],
-      ["accessible_by", "bikes, pedestrians"]
-    ]
-  }
-const expectedPlaces = [expectedPlace1, expectedPlace2];
-
 
   it('displays title and subtitle in the popup', () => {
     cy.window().then((win) => {
@@ -44,7 +20,8 @@ const expectedPlaces = [expectedPlace1, expectedPlace2];
         .within(() => {
           verifyArbitraryPopupContent(expectedPlaces);
 
-//          verifyProblemForm();
+        // TODO BUG: when problem form is opened on desktop, the close button may be hidden
+        // Fix this and add checking problem form in this test
         });
       cy.get('.leaflet-popup-close-button').should('exist').then(($button) => {
         cy.wrap($button).click();

--- a/tests/e2e_tests/e2e_test_data.json
+++ b/tests/e2e_tests/e2e_test_data.json
@@ -129,17 +129,6 @@
         "/test": "/blog/page/about",
         "/static/map.js": "https://cdn.jsdelivr.net/npm/@problematy/goodmap@0.3.4"
       }
-    },
-    {
-      "name": "sendmail",
-      "config": {
-        "port": 465,
-        "smtp_server": "smtp.gmail.com",
-        "receiver_email": "my@gmail.com",
-        "password": "PA$$WORD",
-        "sender_email": "sender@gmail.com",
-        "subject": "New message from website"
-      }
     }
   ]
 }

--- a/tests/e2e_tests/e2e_test_data.json
+++ b/tests/e2e_tests/e2e_test_data.json
@@ -127,7 +127,7 @@
       "name": "redirections",
       "config": {
         "/test": "/blog/page/about",
-        "/static/map.js": "https://cdn.jsdelivr.net/npm/@problematy/goodmap@0.3.4"
+                "/static/map.js": "https://cdn.jsdelivr.net/npm/@problematy/goodmap@0.3.4"
       }
     },
     {

--- a/tests/e2e_tests/e2e_test_data.json
+++ b/tests/e2e_tests/e2e_test_data.json
@@ -127,7 +127,7 @@
       "name": "redirections",
       "config": {
         "/test": "/blog/page/about",
-                "/static/map.js": "https://cdn.jsdelivr.net/npm/@problematy/goodmap@0.3.4"
+        "/static/map.js": "https://cdn.jsdelivr.net/npm/@problematy/goodmap@0.3.4"
       }
     },
     {


### PR DESCRIPTION
The test was derived from `popup-test.cy.js`. By setting `userAgent` property, we are able to simulate a mobile device ( it makes `isMobile` equal to true).
The test opens a mobile popup, checks that all the fields are present, checks that the `report a problem` form is present with all it's available options  and inputs a custom message when choosing the "other" option.