### PR TITLE
chore: new way of running e2e tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,4 +46,4 @@ jobs:
     with:
       goodmap-version: 'main'
       goodmap-e2e-version: 5f81b8a446d988af95799e619d8ea94753167eb8
-      goodmap-frontend-version: ${{ github.sha }}
+      goodmap-frontend-version: 'main'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced inline end-to-end CI steps with a reusable external workflow to centralize E2E execution.
  * Added an e2e-tests job that depends on backend-test and delegates E2E runs to the reusable workflow.
  * Removed local install/run steps for E2E and stress tests and adjusted job dependency ordering.
  * CI now forwards version and frontend identifiers to the reusable workflow for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->