### PR TITLE
Revert "chore(release): 1.8.2 [skip ci]"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 <!-- version list -->
 
-## v1.8.2 (2026-07-06)
-
-### Bug Fixes
-
-- Disable wrong e2e tests temporarily ([#381](https://github.com/Problematy/goodmap/pull/381),
-  [`e73c849`](https://github.com/Problematy/goodmap/commit/e73c8496a9dbc36499614640d208865d9e8a1cf9))
-
-
 ## v1.8.1 (2026-06-14)
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "goodmap"
-version = "1.8.2"
+version = "1.8.1"
 description = "Map engine to serve all the people :)"
 authors = ["Krzysztof Kolodzinski <krzysztof.kolodzinski@problematy.pl>"]
 readme = "README.md"


### PR DESCRIPTION
This reverts commit 3a9062a68bccabb69bcd520f0e63a7e16d95035d.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 1.8.1.
  * Cleaned up the changelog by removing the 1.8.2 release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->